### PR TITLE
Fix : RP-1855 : RStudio : Open link issue, while clicked on open link button the url is redirecting to localhost:8787

### DIFF
--- a/products/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
+++ b/products/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
@@ -85,6 +85,7 @@ http {
       proxy_method POST;
       proxy_set_header Content-Type application/x-www-form-urlencoded;
       proxy_set_body $proxy_body&csrf-token=$request_id;
+      proxy_set_header Host $http_host;
     }
 
     location /auth-sign-in {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RLOpenCatalyst/rgdeploy/179)
<!-- Reviewable:end -->
