### PR TITLE
Update postinstall.sh before breaking change

### DIFF
--- a/products/PCluster/machine-images/config/infra/files/pcluster/postinstall.sh
+++ b/products/PCluster/machine-images/config/infra/files/pcluster/postinstall.sh
@@ -141,6 +141,7 @@ download_packages_yaml() {
 
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
+    SLURM_ROOT="/opt/slurm"
     SLURM_VERSION=$(strings /opt/slurm/lib/libslurm.so | grep  -e '^VERSION'  | awk '{print $2}'  | sed -e 's?"??g')
     LIBFABRIC_MODULE_VERSION=$(grep 'Version:' /opt/amazon/efa/lib64/pkgconfig/libfabric.pc | awk '{print $2}')
     LIBFABRIC_MODULE="libfabric-aws/${LIBFABRIC_MODULE_VERSION}"


### PR DESCRIPTION
This script pulls the `packages-*.yaml` files from the original https://github.com/spack/spack-configs location. PR https://github.com/spack/spack-configs/pull/82 introduces a breaking change since variable `SLURM_ROOT` is introduced in `postinstall.sh` and `packages-*.yaml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RLOpenCatalyst/rgdeploy/185)
<!-- Reviewable:end -->
